### PR TITLE
Improved Windows support

### DIFF
--- a/llmpeg/main.py
+++ b/llmpeg/main.py
@@ -115,6 +115,7 @@ class LLMPEG:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
+                    shell=True,
                 ).stdout,
             )
         elif os_type == "Linux":

--- a/llmpeg/main.py
+++ b/llmpeg/main.py
@@ -6,7 +6,6 @@ from typing import Dict, Optional, Tuple
 import json
 import platform
 import shutil
-import pwd
 import argparse
 import subprocess
 import sys
@@ -160,13 +159,15 @@ class LLMPEG:
 
             # If SHELL variable is not set, fall back to the passwd entry
             try:
+                import pwd
+
                 user = pwd.getpwuid(os.getuid())
                 return user.pw_shell
             except KeyError:
                 return None  # Unable to find the default shell
         elif os_type == "Windows":
-            # TODO:
-            return None
+            # Windows defaults to cmd.exe
+            return "cmd.exe"
         elif os_type == "Darwin":
             # TODO
             return None

--- a/llmpeg/openai_llm.py
+++ b/llmpeg/openai_llm.py
@@ -1,5 +1,6 @@
 """Implementation of LLMInterface for OpenAI LLM API."""
-from openai import OpenAI
+from openai import OpenAI, OpenAIError
+import sys
 from typing import List, Dict
 from llmpeg.llm_interface import LLMInterface
 
@@ -15,7 +16,14 @@ class OpenAILLMInterface(LLMInterface):
         """
         self._model_string = model_string
 
-        self.client = OpenAI()
+        try:
+            self.client = OpenAI()
+        except OpenAIError as e:
+            print(
+                f"OpenAI API Unable to initialize, likely due to missing API Key environment Variable: {e}",  # noqa: E501
+                file=sys.stderr,
+            )
+            exit(1)
 
         self.history: List[Dict[str, str]] = []
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="llmpeg",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/tests/test_openai_llm.py
+++ b/tests/test_openai_llm.py
@@ -1,0 +1,19 @@
+"""Test for functionality of openai_llm.py."""
+import pytest
+from llmpeg.openai_llm import OpenAILLMInterface
+
+
+def test_missing_openai_api_key(monkeypatch):
+    """Test the graceful exit path if OPENAI_API_KEY is not set.
+
+    Args:
+        monkeypatch (_pytest.monkeypatch.MonkeyPatch): A pytest fixture
+    """
+    # Temporarily unset OPENAI_API_KEY
+    # raising=False makes this operation safe if the variable isn't set
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit) as e:
+        _ = OpenAILLMInterface("gpt-3.5-turbo-0125")
+    assert e.type == SystemExit
+    assert e.value.code == 1


### PR DESCRIPTION
# Summary: 0.1.0 -> 0.1.1
This PR introduces improved Windows support. At launch, this tool did not run properly on windows due to using the [`pwd` module](https://docs.python.org/3/library/pwd.html) which is only for Unix systems. The code has been refactored to only import this module on Unix systems. Another minor fix for obtaining the version of windows was implemented.

# Changes
- Fix error due to attempting to import `pwd` on Windows
- Fix error due to trying to run `ver` command without a shell in `subprocess.run` call
- Gracefully exit if `OPENAI_API_KEY` is missing, add test for this case